### PR TITLE
Adding more spawn to Accursed Maze dungeon.

### DIFF
--- a/Spawns/dangers.map
+++ b/Spawns/dangers.map
@@ -6435,6 +6435,7 @@
 *|bandit:mongbat:Gnome:GnomeWarrior:GnomeMage:Kobold:carcassworm:frailskeleton:giantbat:giantlizard:goblin:largespider:phantom:giantrat:slime:bullfrog:largesnake||||||5953|826|0|2|45|60|2|2|6464|1|0|0|0|0|0
 *|bandit:mongbat:Gnome:GnomeWarrior:GnomeMage:Kobold:carcassworm:frailskeleton:giantbat:giantlizard:goblin:largespider:phantom:giantrat:slime:bullfrog:largesnake||||||5956|787|0|2|45|60|2|2|6478|1|0|0|0|0|0
 *|bandit:mongbat:Gnome:GnomeWarrior:GnomeMage:Kobold:carcassworm:frailskeleton:giantbat:giantlizard:goblin:largespider:phantom:giantrat:slime:bullfrog:largesnake||||||5892|788|0|2|45|60|2|2|6220|1|0|0|0|0|0
+*|bandit:mongbat:Gnome:GnomeWarrior:GnomeMage:Kobold:carcassworm:frailskeleton:giantbat:giantlizard:goblin:largespider:phantom:giantrat:slime:bullfrog:largesnake||||||5967|788|0|2|45|60|2|2|6220|1|0|0|0|0|0
 #
 # the Ancient Pyramid-----------------------------------------------------------------------
 #


### PR DESCRIPTION
There was an empty subroom where all others had had at least one spawn in them. This adds to that room to ensure that all are filled.

There is a parameter that I am not sure of in the file that I believe is the spawner's spawn id. I do not know whether they have to be unique and whether anything will go bad if they are not.

Fixes #17 