### PR TITLE
Updated bandage failure to heal 1-3.

### DIFF
--- a/Scripts/Items/Trades/Misc/Bandage.cs
+++ b/Scripts/Items/Trades/Misc/Bandage.cs
@@ -475,7 +475,7 @@ namespace Server.Items
 
 					if ( toHeal < 1 )
 					{
-						toHeal = 1;
+						toHeal = Utility.RandomMinMax(1, 3);
 						healerNumber = 500968; // You apply the bandages, but they barely help.
 					}
 


### PR DESCRIPTION
It looks like the previous code would heal 1 damage at least, but not in every case if the chance of healing is lower than a threshold?

It also looks like the code is spaghetti. It is doing some weird stuff, including taking the Core into consideration (which needs to be rectified).

Every time I turn over a rock it feels like I need to add a new story to go over that file, refactor where necessary, and also clean up the code because it just doesn't make sense.

For instance, in this case in Bandage.cs, the code for checking how much to heal gives a Double value (you can't heal a fraction of a hitpoint). Instead of doing integer division when considering the max values from something like Player.Skill["Anatomy"] / 100, it's then doing typecasting later on and it also causes the value being supplied to the variable toHeal to be a weird way to get a random instead of using the RandomMinMax from the Utility object which would be much cleaner.

Fixes #12 