### PR TITLE
Updated buy chances to 100%

### DIFF
--- a/Scripts/System/Misc/Settings.cs
+++ b/Scripts/System/Misc/Settings.cs
@@ -85,9 +85,9 @@ namespace Server.Misc
 		private static int S_SellCommonChance = 80;
 		private static int S_SellRareChance = 25;
 		private static int S_SellVeryRareChance = 5;
-		private static int S_BuyChance = 50;
-		private static int S_BuyCommonChance = 80;
-		private static int S_BuyRareChance = 70;
+		private static int S_BuyChance = 100;
+		private static int S_BuyCommonChance = 100;
+		private static int S_BuyRareChance = 100;
 		private static bool S_ShinyArmor = true;
 		private static bool S_NewLeather = true;
 		private static bool S_Leopards = true;


### PR DESCRIPTION
I am tired of having to double-check multiple NPCs to see if they will buy the stuff that I am getting when I am killing stuff in dungeons. I am probably losing out on 100's of GP by throwing items on the ground because I A) do not have enough money for a house right now, B) can't use the stuff because it's for a different weapon type (will be fixed in another ticket), and C) am running out of bank storage for the stuff that I can reasonably want to save!

Fixes #3 