### PR TITLE
Fixing oil clothes making too many bandages.

### DIFF
--- a/Scripts/Items/Misc/OilCloth.cs
+++ b/Scripts/Items/Misc/OilCloth.cs
@@ -42,7 +42,7 @@ namespace Server.Items
 			if ( Deleted || !from.CanSee( this ) )
 				return false;
 
-			base.ScissorHelper( from, new Bandage(), Amount );
+			base.ScissorHelper( from, new Bandage(), 1 );
 
 			return true;
 		}


### PR DESCRIPTION
Thought I needed to update the number of bandages that it makes when using the bandage helper method. Turns out it already is making 1 bandage for every 1 oil cloth present. Was making 1 bandage for every AMOUNT present when I did it the old way.

Fixes #83 